### PR TITLE
std::uniform_real_distribution cannot be const anymore in MSVS2022

### DIFF
--- a/common_classes/random.cpp
+++ b/common_classes/random.cpp
@@ -6,14 +6,14 @@ std::mt19937_64 Random::generator_{rd_()};
 
 int Random::nextInt(int bound)
 {
-    const std::uniform_int_distribution<int> distribution(0, bound - 1);
+    std::uniform_int_distribution<int> distribution(0, bound - 1);
     return distribution(generator_);
 }
 
 glm::vec3 Random::getRandomVectorFromRectangleXZ(const glm::vec3& minPosition, const glm::vec3& maxPosition)
 {
-    const std::uniform_real_distribution<float> distributionX(minPosition.x, maxPosition.x);
-    const std::uniform_real_distribution<float> distributionZ(minPosition.z, maxPosition.z);
+    std::uniform_real_distribution<float> distributionX(minPosition.x, maxPosition.x);
+    std::uniform_real_distribution<float> distributionZ(minPosition.z, maxPosition.z);
 
     return glm::vec3(distributionX(generator_), minPosition.y, distributionZ(generator_));
 }


### PR DESCRIPTION
const std::uniform_real_distribution<> was never guaranteed to be usable. The standard did not specify that operator() of std::uniform_real_distribution is const. In particular <random>'s distributions are allowed to have internal state, e.g. to remember unused bits returned from the generator or to store state if the transformation algorithm requires it.

However, standard library implementations are allowed to add const on a non-virtual member function if that wouldn't affect any call to the function that would be well-formed without it according to the standard's specification. Therefore Microsoft's implementation was not non-conforming in allowing you to use the const version, even if that is not guaranteed to work according to the standard.

Nonetheless Microsoft's standard library developers decided to remove the const by-default anyway, to encourage portability with other standard library implementations. They left the option to define _ALLOW_RANDOM_DISTRIBUTION_CONST_OPERATOR (e.g. on the command line /D_ALLOW_RANDOM_DISTRIBUTION_CONST_OPERATOR) to get back the old non-portable behavior if someone really needs it.

All of this is explained and discussed in the corresponding issue https://github.com/microsoft/STL/issues/1912 and the pull request https://github.com/microsoft/STL/pull/2732.

https://stackoverflow.com/questions/73186387/stduniform-real-distribution-cannot-be-const-anymore-in-msvs2022
